### PR TITLE
Fix: String-based service paths in IT tests

### DIFF
--- a/src/integration-test/java/apptest/GroupIT.java
+++ b/src/integration-test/java/apptest/GroupIT.java
@@ -32,9 +32,7 @@ public class GroupIT extends AbstractAppTest {
     @Test
     void test1_getAllGroupsWithCreatorIdSuccess() {
         setupCall()
-                .withServicePath(b -> b.path(PATH)
-                        .queryParam("creatorId", "creator-123")
-                        .build())
+                .withServicePath(PATH + "?creatorId=creator-123")
                 .withHttpMethod(GET)
                 .withExpectedResponseStatus(OK)
                 .withExpectedResponse(EXPECTED_FILE)

--- a/src/integration-test/java/apptest/MessageIT.java
+++ b/src/integration-test/java/apptest/MessageIT.java
@@ -48,9 +48,7 @@ class MessageIT extends AbstractAppTest {
     @Test
     void test3_getMessagesSuccess() {
         setupCall()
-                .withServicePath(b -> b.path(PATH)
-                        .queryParam("sender", "test@sundsvall.se")
-                        .build())
+                .withServicePath(PATH + "?sender=test@sundsvall.se")
                 .withHttpMethod(GET)
                 .withExpectedResponseStatus(OK)
                 .withExpectedResponse(EXPECTED_FILE)


### PR DESCRIPTION
When running all integration tests, some tests failed with 404. This happened because withServicePath() uses a shared builder that keeps data from previous tests, causing wrong paths to be used.
Fix: Changed withServicePath() calls to use plain strings instead of the lambda variant.