### PR TITLE
Secure Notifier API endpoints with JWT authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,25 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- JWT -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.3</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.3</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.3</version>
+			<scope>runtime</scope>
+		</dependency>
+
 		<!-- Other -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/main/java/se/sundsvall/notifier/configuration/JwtAuthenticationFilter.java
+++ b/src/main/java/se/sundsvall/notifier/configuration/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package se.sundsvall.notifier.configuration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtUtil jwtUtil;
+
+	public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+		this.jwtUtil = jwtUtil;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+		@NonNull HttpServletResponse response,
+		@NonNull FilterChain filterChain) throws ServletException, IOException {
+
+		String token = null;
+
+		if (request.getHeader("Authorization") != null) {
+			token = request.getHeader("Authorization").substring(7);
+		} else if (request.getCookies() != null) {
+			for (Cookie cookie : request.getCookies()) {
+				if (cookie.getName().equals("token")) {
+					token = cookie.getValue();
+					break;
+				}
+			}
+		}
+
+		if (token != null && jwtUtil.validateToken(token)) {
+			String email = jwtUtil.extractUsername(token);
+			String role = jwtUtil.extractRole(token);
+
+			var authorities = role != null
+				? List.of(new SimpleGrantedAuthority("ROLE_" + role))
+				: List.<SimpleGrantedAuthority>of();
+
+			var authenticationToken = new UsernamePasswordAuthenticationToken(email, null, authorities);
+			authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+			SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/se/sundsvall/notifier/configuration/JwtUtil.java
+++ b/src/main/java/se/sundsvall/notifier/configuration/JwtUtil.java
@@ -1,0 +1,55 @@
+package se.sundsvall.notifier.configuration;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import java.util.function.Function;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+	@Value("${jwt.secret}")
+	private String secret;
+
+	public String extractUsername(String token) {
+		return extractClaim(token, claims -> claims.get("email", String.class));
+	}
+
+	public Date extractExpiration(String token) {
+		return extractClaim(token, Claims::getExpiration);
+	}
+
+	public String extractRole(String token) {
+		return extractClaim(token, claims -> claims.get("role", String.class));
+	}
+
+	public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+		return claimsResolver.apply(extractAllClaims(token));
+	}
+
+	private Claims extractAllClaims(String token) {
+		return Jwts.parser()
+			.verifyWith(getSignKey())
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+
+	private SecretKey getSignKey() {
+		byte[] keyBytes = Decoders.BASE64.decode(secret);
+		return Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			return !extractExpiration(token).before(new Date());
+		} catch (Exception e) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/se/sundsvall/notifier/configuration/SecurityConfig.java
+++ b/src/main/java/se/sundsvall/notifier/configuration/SecurityConfig.java
@@ -1,0 +1,43 @@
+package se.sundsvall.notifier.configuration;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import se.sundsvall.dept44.util.jacoco.ExcludeFromJacocoGeneratedCoverageReport;
+
+@Configuration
+@EnableWebSecurity
+@Profile("!junit & !it")
+@ExcludeFromJacocoGeneratedCoverageReport
+public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+		this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+	}
+
+	@Bean
+	@Order(Ordered.HIGHEST_PRECEDENCE)
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.securityMatcher("/api/**")
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.anyRequest().authenticated())
+			.exceptionHandling(ex -> ex
+				.authenticationEntryPoint((request, response, authException) -> response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")))
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.build();
+	}
+}

--- a/src/main/resources/application-it.yml
+++ b/src/main/resources/application-it.yml
@@ -2,6 +2,9 @@
 # Test profile settings (IT tests)
 #========================================
 
+jwt:
+  secret: dGVzdFNlY3JldEtleUZvclRlc3RpbmdQdXJwb3Nlc09ubHkxMg==
+
 spring:
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver

--- a/src/main/resources/application-junit.yml
+++ b/src/main/resources/application-junit.yml
@@ -1,6 +1,9 @@
 #========================================
 # Test profile settings (junit tests)
 #========================================
+jwt:
+  secret: dGVzdFNlY3JldEtleUZvclRlc3RpbmdQdXJwb3Nlc09ubHkxMg==
+
 spring:
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,9 @@ spring:
             client-secret: ${ENV_TEAMS_SENDER_CLIENT_SECRET}
             authorization-grant-type: client_credentials
 
+jwt:
+  secret: ${JWT_SECRET}
+
 server:
   port: 8082
 

--- a/src/test/java/se/sundsvall/notifier/configuration/JwtAuthenticationFilterTest.java
+++ b/src/test/java/se/sundsvall/notifier/configuration/JwtAuthenticationFilterTest.java
@@ -1,0 +1,120 @@
+package se.sundsvall.notifier.configuration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+	@Mock
+	private JwtUtil jwtUtil;
+
+	@InjectMocks
+	private JwtAuthenticationFilter filter;
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Mock
+	private FilterChain filterChain;
+
+	@AfterEach
+	void clearSecurityContext() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void doFilterInternal_withValidAuthorizationHeader_setsAuthentication() throws Exception {
+		when(request.getHeader("Authorization")).thenReturn("Bearer validtoken");
+		when(jwtUtil.validateToken("validtoken")).thenReturn(true);
+		when(jwtUtil.extractUsername("validtoken")).thenReturn("user@example.com");
+		when(jwtUtil.extractRole("validtoken")).thenReturn("USER");
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+		assertThat(SecurityContextHolder.getContext().getAuthentication().getName()).isEqualTo("user@example.com");
+		verify(filterChain).doFilter(request, response);
+	}
+
+	@Test
+	void doFilterInternal_withValidCookie_setsAuthentication() throws Exception {
+		when(request.getHeader("Authorization")).thenReturn(null);
+		when(request.getCookies()).thenReturn(new Cookie[] {
+			new Cookie("token", "cookietoken")
+		});
+		when(jwtUtil.validateToken("cookietoken")).thenReturn(true);
+		when(jwtUtil.extractUsername("cookietoken")).thenReturn("user@example.com");
+		when(jwtUtil.extractRole("cookietoken")).thenReturn("USER");
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+		verify(filterChain).doFilter(request, response);
+	}
+
+	@Test
+	void doFilterInternal_withOtherCookieOnly_doesNotSetAuthentication() throws Exception {
+		when(request.getHeader("Authorization")).thenReturn(null);
+		when(request.getCookies()).thenReturn(new Cookie[] {
+			new Cookie("other", "value")
+		});
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+		verify(filterChain).doFilter(request, response);
+	}
+
+	@Test
+	void doFilterInternal_withInvalidToken_doesNotSetAuthentication() throws Exception {
+		when(request.getHeader("Authorization")).thenReturn("Bearer invalidtoken");
+		when(jwtUtil.validateToken("invalidtoken")).thenReturn(false);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+		verify(filterChain).doFilter(request, response);
+	}
+
+	@Test
+	void doFilterInternal_withNoToken_doesNotSetAuthentication() throws Exception {
+		when(request.getHeader("Authorization")).thenReturn(null);
+		when(request.getCookies()).thenReturn(null);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+		verify(filterChain).doFilter(request, response);
+	}
+
+	@Test
+	void doFilterInternal_withNullRole_setsEmptyAuthorities() throws Exception {
+		when(request.getHeader("Authorization")).thenReturn("Bearer validtoken");
+		when(jwtUtil.validateToken("validtoken")).thenReturn(true);
+		when(jwtUtil.extractUsername("validtoken")).thenReturn("user@example.com");
+		when(jwtUtil.extractRole("validtoken")).thenReturn(null);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+		assertThat(SecurityContextHolder.getContext().getAuthentication().getAuthorities()).isEmpty();
+		verify(filterChain).doFilter(request, response);
+	}
+}

--- a/src/test/java/se/sundsvall/notifier/configuration/JwtUtilTest.java
+++ b/src/test/java/se/sundsvall/notifier/configuration/JwtUtilTest.java
@@ -1,0 +1,73 @@
+package se.sundsvall.notifier.configuration;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtUtilTest {
+
+	private static final String TEST_SECRET = "dGVzdFNlY3JldEtleUZvclRlc3RpbmdQdXJwb3Nlc09ubHkxMg==";
+
+	private JwtUtil jwtUtil;
+
+	@BeforeEach
+	void setUp() {
+		jwtUtil = new JwtUtil();
+		ReflectionTestUtils.setField(jwtUtil, "secret", TEST_SECRET);
+	}
+
+	private String generateToken(String email, String role, long expirationMs) {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("email", email);
+		claims.put("role", role);
+		return Jwts.builder()
+			.claims(claims)
+			.issuedAt(new Date())
+			.expiration(new Date(System.currentTimeMillis() + expirationMs))
+			.signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(TEST_SECRET)))
+			.compact();
+	}
+
+	@Test
+	void extractUsername_ok() {
+		var token = generateToken("test@example.com", "USER", 60_000);
+		assertThat(jwtUtil.extractUsername(token)).isEqualTo("test@example.com");
+	}
+
+	@Test
+	void extractRole_ok() {
+		var token = generateToken("test@example.com", "ADMIN", 60_000);
+		assertThat(jwtUtil.extractRole(token)).isEqualTo("ADMIN");
+	}
+
+	@Test
+	void extractExpiration_isInFuture() {
+		var token = generateToken("test@example.com", "USER", 60_000);
+		assertThat(jwtUtil.extractExpiration(token)).isAfter(new Date());
+	}
+
+	@Test
+	void validateToken_valid_returnsTrue() {
+		var token = generateToken("test@example.com", "USER", 60_000);
+		assertThat(jwtUtil.validateToken(token)).isTrue();
+	}
+
+	@Test
+	void validateToken_expired_returnsFalse() {
+		var token = generateToken("test@example.com", "USER", -1_000);
+		assertThat(jwtUtil.validateToken(token)).isFalse();
+	}
+
+	@Test
+	void validateToken_invalid_returnsFalse() {
+		assertThat(jwtUtil.validateToken("not.a.valid.token")).isFalse();
+	}
+}


### PR DESCRIPTION
## Problem
  All `/api/**` endpoints in Notifier were publicly accessible without authentication.
  Anyone could call the API directly from the browser console without being logged in and receive data.

  ## Solution
  The implementation follows the same JWT validation pattern as `api-service-webAppUsers`,                                                                                                                                                                                                                          
  adapted to Notifier's needs (no public auth endpoints to exclude, token validated without email verification). 
  Added a JWT validation filter that verifies incoming requests carry a valid, non-expired token
  issued by webappusers — either as `Authorization: Bearer <token>` header or `token` cookie.
  Security is disabled for `junit` and `it` profiles so existing tests are unaffected.

  ## Changes
  - `pom.xml` — added `jjwt` dependencies
  - `JwtUtil` — parses and validates HMAC-signed JWTs using shared `JWT_SECRET`
  - `JwtAuthenticationFilter` — checks Authorization header and token cookie on incoming requests
  - `SecurityConfig` — enforces authentication on all `/api/**` endpoints
  - `application.yml` — reads `JWT_SECRET` from environment
  - `application-junit.yml` / `application-it.yml` — dummy secret for test profiles

  Closes #140